### PR TITLE
Fix parsing bug for optional and required sections in protocol declaration.

### DIFF
--- a/src/Language/ObjC/Parser/Parser.y
+++ b/src/Language/ObjC/Parser/Parser.y
@@ -348,11 +348,11 @@ proto_decs
 
 
 preq :: { ObjCProtoDeclBlock }
-  : "@required" nonempty_interface_declaration_list
+  : "@required" interface_declaration_list
        {% withNodeInfo $1 $ ObjCReqProtoBlock (reverse $2) }
 
 popt :: { ObjCProtoDeclBlock }
-  : "@optional" nonempty_interface_declaration_list
+  : "@optional" interface_declaration_list
        {% withNodeInfo $1 $ ObjCOptProtoBlock (reverse $2) }
 
 pdef :: { ObjCProtoDeclBlock }


### PR DESCRIPTION
For an example:

```
parseItAll = parseCFile theGCC Nothing ["-I/System/Library/Frameworks/Cocoa.framework/Headers"] "/System/Library/Frameworks/Cocoa.framework/Headers/Cocoa.h"
  where 
    theGCC = newGCC "/usr/bin/gcc"
```

Will fail with the following error on 10.8 prior to this fix:

```
Left /System/Library/Frameworks/AppKit.framework/Headers/NSPageController.h:98: (column 1) [ERROR]  >>> Syntax Error !
  Syntax error !
  The symbol `@optional' does not fit here.
```
